### PR TITLE
Update schema definition of MF-JSON

### DIFF
--- a/json-schema/MF-JSON_Prism.schema.json
+++ b/json-schema/MF-JSON_Prism.schema.json
@@ -2,19 +2,16 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://www.opengis.net/spec/movingfeatures/json/1.0/prism/MF-JSON_Prism.schema.json",
   "title": "OGC Moving Feature JSON Prism schema",
-  "oneOf":[
-    {"$ref": "#/definitions/temporalGeometry"},
-    {"$ref": "#/definitions/temporalProperties"},
-    {"$ref": "#/definitions/crs"},
-    {"$ref": "#/definitions/trs"},
-    {"$ref": "#/definitions/movingFeature"},
-    {"$ref": "#/definitions/movingFeatureCollection"},
-    {"$ref": "#/definitions/time"},
-    {"$ref": "#/definitions/bbox"},
-    {"$ref": "#/definitions/geometry"},
-    {"$ref": "#/definitions/geometryInterpolation"}
-  ],
+  "type": "object",
+  "$ref": "#/definitions/mfjsonPrism",
   "definitions": {
+    "mfjsonPrism": {
+      "$id": "#/definitions/mfjsonPrism",
+      "oneOf": [
+        {"$ref": "#/definitions/movingFeature"},
+        {"$ref": "#/definitions/movingFeatureCollection"}
+      ]
+    },
     "temporalGeometry": {
       "$id": "#/definitions/temporalGeometry",
       "title": "TemporalGeometry Object",

--- a/json-schema/MF-JSON_Prism.schema.json
+++ b/json-schema/MF-JSON_Prism.schema.json
@@ -262,7 +262,7 @@
       "type": "object",
       "required": ["datetimes"],
       "properties": {
-        "datetimes": {"$ref": "#/definitions/datetimes"}
+        "datetimes": {"$ref": "#/definitions/prametricValuesDatetimes"}
       },
       "patternProperties": {
         "^S_": {
@@ -274,13 +274,22 @@
         }
       }
     },
+    "prametricValuesDatetimes": {
+      "$id": "#/definitions/prametricValuesDatetimes",
+      "type": [ "null", "array" ],
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    },
     "measureType": {
       "$id": "#/definitions/measureType",
       "type": "object",
       "required": ["type", "values"],
       "properties": {
         "type": {"type": "string", "enum": ["Measure"]},
-        "values": {"type": "array", "items": {"type": ["null", "number"]}},
+        "values": {"type": ["null", "array"], "items": {"type": ["null", "number"]}},
         "interpolation": {"$ref": "#/definitions/propertyInterpolation"},
         "form": {
           "oneOf": [
@@ -297,7 +306,7 @@
       "required": ["type", "values"],
       "properties": {
         "type": {"type": "string", "enum": ["Text"]},
-        "values": {"type": "array", "items": {"type": ["null", "string", "boolean"]}},
+        "values": {"type": ["null", "array"], "items": {"type": ["null", "string", "boolean"]}},
         "interpolation": {"$ref": "#/definitions/propertyInterpolation"},
         "description": {"type": "string"}
       }
@@ -308,7 +317,7 @@
       "required": ["type", "values"],
       "properties": {
         "type": {"type": "string", "enum": ["Image"]},
-        "values": {"type": "array", "items": {"type": ["null", "string"]}},
+        "values": {"type": ["null", "array"], "items": {"type": ["null", "string"]}},
         "interpolation": {
           "$ref": "#/definitions/propertyInterpolation"
         },

--- a/json-schema/MF-JSON_Prism.schema.json
+++ b/json-schema/MF-JSON_Prism.schema.json
@@ -34,7 +34,7 @@
       "title": "Coordinate Reference System",
       "type": "object",
       "required": ["type", "properties"],
-      "oneOf":[
+      "oneOf": [
         {"$ref": "#/definitions/namedCRS"},
         {"$ref": "#/definitions/linkedCRS"}
       ]
@@ -44,7 +44,7 @@
       "title": "Temporal Coordinate Reference System",
       "type": "object",
       "required": ["type", "properties"],
-      "oneOf":[
+      "oneOf": [
         {"$ref": "#/definitions/namedTRS"},
         {"$ref": "#/definitions/linkedCRS"}
       ]
@@ -63,8 +63,8 @@
         "crs": {"$ref": "#/definitions/crs"},
         "trs": {"$ref": "#/definitions/trs"},
         "temporalProperties": {"$ref": "#/definitions/temporalProperties"},
-        "bbox": {"$ref": "#/definitions/bbox"},
-        "time": {"$ref": "#/definitions/time"},
+        "bbox": {"$ref": "#/definitions/boundingBox"},
+        "time": {"$ref": "#/definitions/lifeSpan"},
         "geometry": {"$ref": "#/definitions/geometry"},
         "properties": {"$ref": "#/definitions/properties"},
         "id": {
@@ -93,13 +93,13 @@
         },
         "crs": {"$ref": "#/definitions/crs"},
         "trs": {"$ref": "#/definitions/trs"},
-        "bbox": {"$ref": "#/definitions/bbox"},
-        "time": {"$ref": "#/definitions/time"},
+        "bbox": {"$ref": "#/definitions/boundingBox"},
+        "time": {"$ref": "#/definitions/lifeSpan"},
         "label": {"type": ["null", "string"]}
       }
     },
     "lifeSpan": {
-      "$id": "#/definitions/time",
+      "$id": "#/definitions/lifeSpan",
       "title": "LifeSpan Object",
       "type": ["null", "array"],
       "minItems": 2,
@@ -108,7 +108,7 @@
       "items": {"type": "string"}
     },
     "boundingBox": {
-      "$id": "#/definitions/bbox",
+      "$id": "#/definitions/boundingBox",
       "title": "BoundingBox Object",
       "type": ["null", "array"],
       "minItems": 4,
@@ -189,9 +189,9 @@
             }
           ]
         },
-        "interpolation": {"$ref": "#/definitions/geometryInterpolation"},
+        "interpolation": {"$ref": "#/definitions/motionCurve"},
         "base": {
-          "oneOf":[
+          "oneOf": [
             {"type": "null"},
             {
               "type": "object",
@@ -212,9 +212,9 @@
       }
     },
     "motionCurve": {
-      "$id": "#/definitions/geometryInterpolation",
+      "$id": "#/definitions/motionCurve",
       "title": "Interpolation method for TemporalPrimitiveGeometry",
-      "oneOf":[
+      "oneOf": [
         {
           "type": "string",
           "enum": ["Discrete", "Step", "Linear", "Quadratic", "Cubic"],
@@ -241,7 +241,7 @@
         "trs": {"$ref": "#/definitions/trs"}
       }
     },
-    "orientation":{
+    "orientation": {
       "$id": "#/definitions/orientation",
       "type": "object",
       "required": ["scales", "angles"],
@@ -258,7 +258,7 @@
           "maxItems": 3,
           "items": {"type": "number"}
         }
-      },
+      }
     },
     "prametricValues": {
       "$id": "#/definitions/prametricValues",
@@ -286,11 +286,11 @@
         "values": {"type": "array", "items": {"type": ["null", "number"]}},
         "interpolation": {"$ref": "#/definitions/propertyInterpolation"},
         "form": {
-            "oneOf": [
-              {"type": "string", "minLength": 3, "maxLength": 3},
-              {"type": "string", "format": "uri"}
-            ]
-          },
+          "oneOf": [
+            {"type": "string", "minLength": 3, "maxLength": 3},
+            {"type": "string", "format": "uri"}
+          ]
+        },
         "description": {"type": "string"}
       }
     },
@@ -321,7 +321,7 @@
     "propertyInterpolation": {
       "$id": "#/definitions/propertyInterpolation",
       "title": "Interpolation method for ParametricValues",
-      "oneOf":[
+      "oneOf": [
         {
           "type": "string",
           "enum": ["Discrete", "Step", "Linear", "Regression"],

--- a/json-schema/MF-JSON_Trajectory.schema.json
+++ b/json-schema/MF-JSON_Trajectory.schema.json
@@ -4,11 +4,15 @@
   "type": "object",
   "title": "OGC Moving Feature JSON Trajecotry schema",
   "required": [ "type" ],
-  "oneOf":[
-    {"$ref": "#/definitions/feature"},
-    {"$ref": "#/definitions/featureCollection"}
-  ],
+  "$ref": "#/definitions/mfjsonTrajectory",
   "definitions": {
+    "mfjsonTrajectory": {
+      "$id": "#/definitions/mfjsonTrajectory",
+      "oneOf":[
+        {"$ref": "#/definitions/feature"},
+        {"$ref": "#/definitions/featureCollection"}
+      ],
+    },
     "feature": {
       "title": "Feature",
       "description": "A MF-JSON trajectory feature",

--- a/json-schema/mf_prism_example.json
+++ b/json-schema/mf_prism_example.json
@@ -26,7 +26,7 @@
         "base": {
           "type": "glTF",
           "href": "http://www.opengis.net/spec/movingfeatures/json/1.0/prism/example/car3dmodel.gltf"
-        },
+        }
     },
     "temporalProperties": [
       {


### PR DESCRIPTION
When recording spontaneous data in 'prametricValues',
the definition at '#/definitions/datetimes' requires two or more elements and is therefore incompatible.
As a workaround, a new definition called 'prametricValuesDatetimes' was added.
Additionally, the values of 'measureType', 'textType', and 'imageType' were updated to allow null instead of an array.
